### PR TITLE
Include jsDocs for object properties in schema

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@noom/symbolism-cli",
   "version": "0.3.0",
   "description": "Coverage assertions for specific code tokens.",
-  "main": "dist/index.js",
+  "main": "dist/noom-symbolism-cli.cjs.js",
   "bin": {
     "symbolism": "bin/symbolism.js"
   },

--- a/packages/cli/src/actions/tests/dump-schema.test.ts
+++ b/packages/cli/src/actions/tests/dump-schema.test.ts
@@ -59,7 +59,9 @@ describe("dumpSchema", () => {
             ]
           },
           \\"merged\\": {
-            \\"type\\": \\"number\\"
+            \\"type\\": \\"number\\",
+            \\"documentationComment\\": [],
+            \\"jsDocTags\\": []
           }
         }
       }"

--- a/packages/coverage/package.json
+++ b/packages/coverage/package.json
@@ -2,7 +2,7 @@
   "name": "@noom/symbolism-coverage",
   "version": "0.3.0",
   "description": "Coverage assertions for specific code tokens.",
-  "main": "dist/index.js",
+  "main": "dist/noom-symbolism-coverage.cjs.js",
   "author": "Kevin Decker <kpdecker@gmail.com>",
   "license": "MIT",
   "repository": {

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -2,7 +2,7 @@
   "name": "@noom/symbolism-definitions",
   "version": "0.3.0",
   "description": "Symbolism utilities",
-  "main": "dist/index.js",
+  "main": "dist/noom-symbolism-definitions.cjs.js",
   "author": "Kevin Decker <kpdecker@gmail.com>",
   "license": "MIT",
   "repository": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -8,7 +8,7 @@
     "eslint-plugin"
   ],
   "author": "@noom/symbolism-eslint-plugin",
-  "main": "./dist/index.js",
+  "main": "dist/noom-symbolism-eslint-plugin.cjs.js",
   "scripts": {
     "lint": "eslint ."
   },

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -2,7 +2,7 @@
   "name": "@noom/symbolism-paths",
   "version": "0.3.0",
   "description": "Symbolism utilities",
-  "main": "dist/index.js",
+  "main": "dist/noom-symbolism-paths.cjs.js",
   "author": "Kevin Decker <kpdecker@gmail.com>",
   "license": "MIT",
   "repository": {

--- a/packages/symbol-table/package.json
+++ b/packages/symbol-table/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git+https://github.com/noom/symbolism.git"
   },
-  "main": "dist/index.js",
+  "main": "dist/noom-symbolism-symbol-table.cjs.js",
   "dependencies": {
     "@noom/symbolism-definitions": "^0.3.0",
     "@noom/symbolism-paths": "^0.3.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -2,7 +2,7 @@
   "name": "@noom/symbolism-test",
   "version": "0.3.0",
   "description": "Symbolism utilities",
-  "main": "dist/index.js",
+  "main": "dist/noom-symbolism-test.cjs.js",
   "author": "Kevin Decker <kpdecker@gmail.com>",
   "license": "MIT",
   "repository": {

--- a/packages/ts-debug/package.json
+++ b/packages/ts-debug/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git+https://github.com/noom/symbolism.git"
   },
-  "main": "dist/index.js",
+  "main": "dist/noom-symbolism-ts-debug.cjs.js",
   "dependencies": {
     "@noom/symbolism-utils": "^0.3.0",
     "@noom/symbolism-ts-utils": "^0.3.0",

--- a/packages/ts-utils/package.json
+++ b/packages/ts-utils/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git+https://github.com/noom/symbolism.git"
   },
-  "main": "dist/index.js",
+  "main": "dist/noom-symbolism-ts-utils.cjs.js",
   "dependencies": {
     "@noom/symbolism-utils": "^0.3.0",
     "tiny-invariant": "^1.2.0"

--- a/packages/type-eval/package.json
+++ b/packages/type-eval/package.json
@@ -2,7 +2,7 @@
   "name": "@noom/symbolism-type-eval",
   "version": "0.3.0",
   "description": "Symbolism utilities",
-  "main": "dist/index.js",
+  "main": "dist/noom-symbolism-type-eval.cjs.js",
   "author": "Kevin Decker <kpdecker@gmail.com>",
   "license": "MIT",
   "repository": {

--- a/packages/type-eval/src/print/json.ts
+++ b/packages/type-eval/src/print/json.ts
@@ -38,7 +38,11 @@ export function schemaToJson(
 
   switch (schema.kind) {
     case "primitive":
-      return { type: schema.name };
+      return {
+        type: schema.name,
+        documentationComment: schema.node?.symbol?.getDocumentationComment?.() ?? [],
+        jsDocTags: schema.node?.symbol?.getJsDocTags?.() ?? [],
+      };
     case "literal":
       if (typeof schema.value === "bigint") {
         return { const: `"${schema.value}"` };

--- a/packages/type-eval/src/tests/object.test.ts
+++ b/packages/type-eval/src/tests/object.test.ts
@@ -40,6 +40,10 @@ describe("type schema converter", () => {
         const zeeRealString = 'real!';
 
         declare const zeeObject: Record<string, number> & {
+          /**
+           * this is a comment
+           * @deprecated dont use this anymore
+           */
           extra: string;
           [key: \`foo\${string}\`]: string;
         };
@@ -116,17 +120,23 @@ describe("type schema converter", () => {
           "$schema": "https://json-schema.org/draft/2020-12/schema",
           "patternProperties": Object {
             "/^.*$/": Object {
+              "documentationComment": Array [],
+              "jsDocTags": Array [],
               "type": "number",
             },
             "/^.*fooreal!$/": Object {
               "const": "literal!",
             },
             "/^foo.*$/": Object {
+              "documentationComment": Array [],
+              "jsDocTags": Array [],
               "type": "string",
             },
           },
           "properties": Object {
             "bothor": Object {
+              "documentationComment": Array [],
+              "jsDocTags": Array [],
               "type": "string",
             },
             "directUnion": Object {
@@ -138,6 +148,23 @@ describe("type schema converter", () => {
               "type": "string",
             },
             "extra": Object {
+              "documentationComment": Array [
+                Object {
+                  "kind": "text",
+                  "text": "this is a comment",
+                },
+              ],
+              "jsDocTags": Array [
+                Object {
+                  "name": "deprecated",
+                  "text": Array [
+                    Object {
+                      "kind": "text",
+                      "text": "dont use this anymore",
+                    },
+                  ],
+                },
+              ],
               "type": "string",
             },
             "gettor": Object {
@@ -167,6 +194,8 @@ describe("type schema converter", () => {
               "$ref": "#/$defs/Source",
             },
             "string": Object {
+              "documentationComment": Array [],
+              "jsDocTags": Array [],
               "type": "string",
             },
           },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,7 +2,7 @@
   "name": "@noom/symbolism-utils",
   "version": "0.3.0",
   "description": "Symbolism utilities",
-  "main": "dist/index.js",
+  "main": "dist/noom-symbolism-utils.cjs.js",
   "author": "Kevin Decker <kpdecker@gmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Include js docs and tags for object properties when dumping schema.
These will be used to include comments in generated proto files in noom-contracts